### PR TITLE
feat: Add AZ CLI completion to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -41,7 +41,9 @@ autoload bashcompinit && bashcompinit
 autoload -Uz compinit && compinit
 
 # AZ CLI completion
-source $(brew --prefix)/etc/bash_completion.d/az
+if [ -f "$(brew --prefix)/etc/bash_completion.d/az" ]; then
+    source "$(brew --prefix)/etc/bash_completion.d/az"
+fi
 
 # AWS CLI completion
 if [ -f "/opt/homebrew/bin/aws_completer" ]; then

--- a/.zshrc
+++ b/.zshrc
@@ -40,6 +40,9 @@ fi
 autoload bashcompinit && bashcompinit
 autoload -Uz compinit && compinit
 
+# AZ CLI completion
+source $(brew --prefix)/etc/bash_completion.d/az
+
 # AWS CLI completion
 if [ -f "/opt/homebrew/bin/aws_completer" ]; then
     complete -C '/opt/homebrew/bin/aws_completer' aws


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change adds support for Azure CLI command completion.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R43-R47): Added a conditional statement to source Azure CLI completion script if it exists.