### PR TITLE
feat: Add Rust environment setup to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -83,3 +83,15 @@ fi
 if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
   . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
 fi
+
+# ------------------------------------------------------------------------
+# Rust bits
+# ------------------------------------------------------------------------
+
+# Add Cargo's bin directory ($HOME/.cargo/bin) to PATH
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Load Rust environment variables from Cargo if available
+if [ -f "$HOME/.cargo/env" ]; then
+    source "$HOME/.cargo/env"
+fi


### PR DESCRIPTION
This pull request includes changes to the `.zshrc` file to add Rust-related configurations. The most important changes include adding Cargo's bin directory to the PATH and loading Rust environment variables if available.

Rust environment setup:

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R86-R97): Added Cargo's bin directory (`$HOME/.cargo/bin`) to the PATH.
* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R86-R97): Added a conditional check to load Rust environment variables from Cargo if the file `$HOME/.cargo/env` exists.